### PR TITLE
Update Dungeon formula to work on Apple Silicon

### DIFF
--- a/Formula/dungeon.rb
+++ b/Formula/dungeon.rb
@@ -18,17 +18,17 @@ class Dungeon < Formula
     chdir "src" do
       # look for game files where homebrew installed them, not pwd
       inreplace "game.f" do |s|
-        s.gsub! "FILE='dindx',STATUS='OLD',", "FILE='#{opt_pkgshare}/dindx',"
+        s.gsub! "FILE='dindx',STATUS='OLD',", "FILE='#{opt_share}/dindx',"
         s.gsub! "1\tFORM='FORMATTED',ACCESS='SEQUENTIAL',ERR=1900)", "1\tSTATUS='OLD',FORM='FORMATTED'," \
                                                                      "\n\t2\tACCESS='SEQUENTIAL',ERR=1900)"
-        s.gsub! "FILE='dtext',STATUS='OLD',", "FILE='#{opt_pkgshare}/dtext',"
+        s.gsub! "FILE='dtext',STATUS='OLD',", "FILE='#{opt_share}/dtext',"
         s.gsub! "1\tFORM='UNFORMATTED',ACCESS='DIRECT',", "1\tSTATUS='OLD',FORM='UNFORMATTED',ACCESS='DIRECT',"
       end
       system "make"
       bin.install "dungeon"
     end
-    pkgshare.install "dindx"
-    pkgshare.install "dtext"
+    share.install "dindx"
+    share.install "dtext"
     man.install "dungeon.txt"
     man.install "hints.txt"
   end


### PR DESCRIPTION
I just got an M1 MacBook so I finally managed to troubleshoot why this formula wasn't building on Apple Silicon. The `opt_pkgshare` path on Arm was so long it overran column 72 and made gfortran flame out. Installing the files to `opt_share` instead seems to fix the problem on my machine.

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
